### PR TITLE
Sticky Contact Bar Fix

### DIFF
--- a/frontend/src/pages/project/Project.scss
+++ b/frontend/src/pages/project/Project.scss
@@ -35,12 +35,7 @@
 
 .RecentProjectsContainer {
     background: var(--tertiary-color);
-    min-height: 520px;
     padding: 40px 0;
-
-    @media (max-width: $mobile-landscape-breakpoint) {
-        min-height: 920px;
-    }
 
     .RecentProjectsHeader {
         font-size: 32px;

--- a/frontend/src/pages/project/Project.scss
+++ b/frontend/src/pages/project/Project.scss
@@ -60,4 +60,8 @@
             border: 8px solid var(--tertiary-color) !important;
         }
     }
+
+    .NoOtherProjectsMessage {
+        text-align: center;
+    }
 }

--- a/frontend/src/pages/project/Project.tsx
+++ b/frontend/src/pages/project/Project.tsx
@@ -167,7 +167,13 @@ const Project = () => {
                   <div className="RecentProjectsContainer">
                     <h2 className="RecentProjectsHeader">Recent Projects</h2>
                     <div className="SmallDivider" />
-                    <ProjectCards { ...projectCardsProps! } />
+                    {
+                      projectCardsProps?.projectCardsProps.length
+                        ?
+                        <ProjectCards { ...projectCardsProps! } />
+                        :
+                        <h2><em>No other projects available right now...</em></h2>
+                    }
                   </div>
                   <ContactBanner { ...contactBannerProps! } />
                 </div>

--- a/frontend/src/pages/project/Project.tsx
+++ b/frontend/src/pages/project/Project.tsx
@@ -138,11 +138,11 @@ const Project = () => {
               // load Project content when set
               project
               ?
-                <>
+                <div>
                   <div className="ProjectContent Content LargeHeaderOverlap">
                   {
                     // check if alternative image is defined and display dynamically
-                    project.hasOwnProperty('alt_img')
+                    project.hasOwnProperty('alt_img') && project.alt_img
                       ?
                       <div style={{ backgroundImage: `url(${project.alt_img.url})` }}
                            className="ProjectAltImg"/>
@@ -170,7 +170,7 @@ const Project = () => {
                     <ProjectCards { ...projectCardsProps! } />
                   </div>
                   <ContactBanner { ...contactBannerProps! } />
-                </>
+                </div>
               :
                 null
             }

--- a/frontend/src/pages/project/Project.tsx
+++ b/frontend/src/pages/project/Project.tsx
@@ -172,7 +172,7 @@ const Project = () => {
                         ?
                         <ProjectCards { ...projectCardsProps! } />
                         :
-                        <h2><em>No other projects available right now...</em></h2>
+                        <h2 className="NoOtherProjectsMessage"><em>No other projects available right now...</em></h2>
                     }
                   </div>
                   <ContactBanner { ...contactBannerProps! } />


### PR DESCRIPTION
This PR is a quick patch update to address the strange overlapping contact bar on `Project` page. This PR also addresses the no projects in the Recent Projects section and the sizing of that component.

**Requirements:**
- [x] Nest main Project page content inside a `div` in order to have the contact bar stick to the bottom of the aforementioned element.
- [x] Have a dynamic message that notifies user that there is not other projects in **Recent Projects** area.
- [x] Remove min-height on **Recent Projects** component to avoid too much empty space without project cards available.